### PR TITLE
Added preview delay

### DIFF
--- a/editor.html
+++ b/editor.html
@@ -20,15 +20,19 @@
 			if (editor.getValue().length > 0) {
         		        var converter = new Showdown.converter();
         		        var ret = converter.makeHtml(editor.getValue());
-        		        document.getElementById("preview-container").innerHTML = ret;
-                                document.getElementById("preview-container").setAttribute("class", "nothidden");
-                                document.getElementById("preview-header").setAttribute("class", "nothidden");
-				document.getElementById("preview-header").innerHTML = "Preview";
+                                setTimeout(function () {
+        		                document.getElementById("preview-container").innerHTML = ret;
+                                        document.getElementById("preview-container").setAttribute("class", "nothidden");
+                                        document.getElementById("preview-header").setAttribute("class", "nothidden");
+			         	document.getElementById("preview-header").innerHTML = "Preview";
+                                }, 5000);
 			} else {
-                                document.getElementById("preview-container").innerHTML = "";
-                                document.getElementById("preview-container").setAttribute("class", "hidden");
-                                document.getElementById("preview-header").setAttribute("class", "hidden");
-				document.getElementById("preview-header").innerHTML = "";
+                                setTimeout(function () {
+                                        document.getElementById("preview-container").innerHTML = "";
+                                        document.getElementById("preview-container").setAttribute("class", "hidden");
+                                        document.getElementById("preview-header").setAttribute("class", "hidden");
+			         	document.getElementById("preview-header").innerHTML = "";
+                                }, 5000);
 			}
 		}
 		


### PR DESCRIPTION
Added a 5 second delay between the editor having text typed into it and the preview appearing. This also happens when it is disappearing.

This delay makes the editor better to use as it allows the user time to have typed a few words before the preview appears, however if they *want* to see just one character in the preview then they can. They must just wait for the preview to appear.

Having a pause with an empty preview also makes the editor better as the user has time to *see* that the preview does indeed have no output in it. Therefore, a novice programmer will know that the preview is being hidden as it is empty rather than just randomly going away.